### PR TITLE
update memory requirements-review exact in future

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/bayarea_urbansim"
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = "80000"
-    vb.cpus = 12
+    vb.memory = "50000"
+    vb.cpus = 8
   end
 
   config.vm.provision :shell, :inline => 'apt-get -y install dos2unix'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/bayarea_urbansim"
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = "20000"
-    vb.cpus = 4
+    vb.memory = "80000"
+    vb.cpus = 12
   end
 
   config.vm.provision :shell, :inline => 'apt-get -y install dos2unix'


### PR DESCRIPTION
running at dd89fbc2b49cbc816b7b052a01e761d2fbd2e6b2 with 20GB of RAM resulted in errors like in the following log, truncated to a 2025 start year iteration: 

Running iteration 4 with iteration value 2025
Running step 'neighborhood_vars'
Computing accessibility variables
Computing retail_sqft_3000
Computing sum_income_3000
Computing residential_units_500
Removed 2 rows because they contain missing values
Computing residential_units_1500
Removed 2 rows because they contain missing values
Computing office_1500
Computing retail_1500
Computing industrial_1500
Computing ave_sqft_per_unit
Computing ave_lot_size_per_unit
Computing population
Computing poor
Computing renters
Computing sfdu
Computing ave_hhsize
Computing jobs_500
Computing jobs_1500
Computing ave_income_1500
Computing ave_income_500
       retail_sqft_3000  sum_income_3000  residential_units_500  \
count     226060.000000     2.260600e+05          226060.000000   
mean      514601.093750     8.186803e+08               4.008299   
std       847934.219939     1.118725e+09               1.692599   
min            0.000000     0.000000e+00               0.000000   
25%        56618.149414     2.632395e+08               3.440274   
50%       272646.750000     5.770984e+08               4.442534   
75%       641890.578125     9.840814e+08               5.075507   
max     11094387.000000     1.072621e+10               8.623929   

       residential_units_1500    office_1500    retail_1500  industrial_1500  \
count           226060.000000  226060.000000  226060.000000    226060.000000   
mean                 5.997278       4.531892       3.736140         2.274047   
std                  1.835685       2.477304       2.597060         2.581628   
min                  0.000000       0.000000       0.000000         0.000000   
25%                  5.545972       3.092248       0.409149         0.000000   
50%                  6.470693       4.934555       4.488975         0.855005   
75%                  7.059947       6.273703       5.836286         4.546617   
max                 10.175836      11.856349       9.420264         8.900290   

       ave_sqft_per_unit  ave_lot_size_per_unit     population           poor  \
count      226060.000000          226060.000000  226060.000000  226060.000000   
mean            7.255086               8.926395       6.908341       5.537005   
std             1.255617               1.913783       1.958407       1.916655   
min             0.000000               0.000000       0.000000       0.000000   
25%             7.279513               8.571193       6.502759       4.857898   
50%             7.436715               8.862389       7.431835       5.954041   
75%             7.607866               9.342524       8.021528       6.715147   
max             8.699681              17.866968      11.003386      10.046861   

             renters           sfdu     ave_hhsize       jobs_500  \
count  226060.000000  226060.000000  226060.000000  226060.000000   
mean        4.161728       5.343798       1.264808       2.587485   
std         1.564140       1.748683       0.221684       2.398809   
min         0.000000       0.000000       0.000000       0.000000   
25%         3.625940       4.961127       1.275444       0.000000   
50%         4.528810       5.906592       1.299841       2.395020   
75%         5.132009       6.438262       1.324905       4.576825   
max         8.101633       8.095656       2.564949      10.750320   

           jobs_1500  ave_income_1500  ave_income_500  
count  226060.000000    226060.000000   226060.000000  
mean        5.219362        11.247046       10.240328  
std         2.370504         1.918674        2.917277  
min         0.000000         0.000000        0.000000  
25%         3.949822        11.440366       10.855165  
50%         5.626673        11.589896       11.050906  
75%         6.869481        11.712194       11.225257  
max        11.964272        13.402191       13.477238  
Time to execute step 'neighborhood_vars': 44.90 s
Running step 'regional_vars'
Computing accessibility variables
Computing residential_units_45
Removed 2 rows because they contain missing values
Computing jobs_15
Computing jobs_45
Computing sum_income_40
       residential_units_45       jobs_15       jobs_45  sum_income_40  \
count          12016.000000  12016.000000  12016.000000   1.201600e+04   
mean              13.221551     11.509756     13.533693   1.077211e+11   
std                0.777166      1.415702      0.914888   4.163728e+10   
min                0.000000      0.000000      5.209556   0.000000e+00   
25%               13.180055     10.981910     13.476857   9.100954e+10   
50%               13.484792     11.734531     13.877741   1.161803e+11   
75%               13.658221     12.498994     14.057650   1.365286e+11   
max               13.886653     13.310191     14.256533   1.807440e+11   

        embarcadero    pacheights      stanford  
count  12016.000000  12016.000000  12016.000000  
mean      34.742410     69.130263     56.614012  
std       18.559806     16.907736     25.413248  
min        0.000000      0.000000      0.000000  
25%       18.397501     75.000000     25.857000  
50%       34.338501     75.000000     75.000000  
75%       49.097249     75.000000     75.000000  
max       75.000000     75.000000     75.000000  
Time to execute step 'regional_vars': 39.01 s
Running step 'rsh_simulate'
count    1844100.000000
mean         379.535069
std          259.389278
min        -4658.329900
25%          289.672207
50%          377.869831
75%          474.267924
max         1326.292725
dtype: float64
Clipped rsh_simulate produces
count    1844100.000000
mean         394.377161
std          139.078102
min          200.000000
25%          289.672207
50%          377.869831
75%          474.267924
max         1326.292725
Name: residential_price, dtype: float64
Time to execute step 'rsh_simulate': 7.43 s
Running step 'nrh_simulate'
count    88231.000000
mean        20.729517
std          9.684767
min          4.575941
25%         13.266310
50%         20.020095
75%         24.699525
max         77.783550
dtype: float64
Time to execute step 'nrh_simulate': 3.79 s
Running step 'households_relocation'
Total agents: 2853146
Total currently unplaced: 0
Assigning for relocation...
Total currently unplaced: 998601
Time to execute step 'households_relocation': 1.89 s
Running step 'households_transition'
Distribution by income before:
1    0.271035
4    0.256521
2    0.248049
3    0.224394
dtype: float64
Total agents before transition: 2853146
Total agents after transition: 2985249
Distribution by income after:
1    0.272559
4    0.263086
2    0.241626
3    0.222729
dtype: float64
Time to execute step 'households_transition': 2.10 s
Running step 'jobs_relocation'
Total agents: 3783716
Total currently unplaced: 0
Assigning for relocation...
Total currently unplaced: 1324300
Time to execute step 'jobs_relocation': 1.38 s
Running step 'jobs_transition'
Total agents before transition: 3783716
Total agents after transition: 3989770
Time to execute step 'jobs_transition': 3.59 s
Running step 'price_vars'
Computing accessibility variables
Computing residential
Removed 2 rows because they contain missing values
Computing retail
Computing office
Computing industrial
         residential         retail         office     industrial
count  226060.000000  226060.000000  226060.000000  226060.000000
mean      433.091095      19.184681      23.757341       8.709653
std       136.553947      10.919796      11.335822       7.147094
min        -1.000000      -1.000000      -1.000000      -1.000000
25%       339.220551      17.590477      17.848444      -1.000000
50%       416.018112      21.256016      21.989590      10.178159
75%       507.975960      23.845036      29.375250      12.753742
max      1160.654419      73.534698      68.692116      35.054081
Time to execute step 'price_vars': 10.72 s
Running step 'scheduled_development_events'
Demolishing/building 15 buildings
Unplaced households before: 1130704
Unplaced households after: 1130952
Unplaced jobs before: 1531158
Unplaced jobs after: 1531221
Demolished 13 buildings
    (this number is smaller when parcel has no existing buildings)
Adding 26 buildings as scheduled development events
Res units before: 2,941,242.0
Non-res sqft before: 2,455,599,461.92
Res units after: 2,957,429.0
Non-res sqft after: 2,462,627,989.92
Time to execute step 'scheduled_development_events': 3.09 s
Running step 'lump_sum_accounts'
Time to execute step 'lump_sum_accounts': 0.00 s
Running step 'subsidized_residential_developer_lump_sum_accts'
Running the subsidized developer for acct: OBAG
Describe of the yearly rent by use
              retail     industrial         office    residential
count  517438.000000  517438.000000  517438.000000  517438.000000
mean       21.249563       9.934626      24.147480      33.455312
std        13.700748       7.347748      11.314499      11.899691
min        -1.000000      -1.000000      -1.000000       7.500000
25%        17.625433       7.074691      17.490406      24.768718
50%        21.949305      10.646568      22.560308      29.967470
75%        25.263906      13.406188      30.864397      39.624400
max        73.534698      34.648678      68.692116      62.500000
Computing feasibility for form residential
Making policy modifications to profitability
Sum of residential fees:  0.0
Computing adjustments due to inclusionary housing
Revenue difference per unit (not zero values)
count     408698.000000
mean      926605.630747
std       504082.865241
min        19454.899536
25%       549386.582991
50%       787704.468054
75%      1189174.015361
max      2962899.512691
dtype: float64
Feasibile affordable units by jurisdiction
juris_name
Tiburon                   12
Belvedere                 12
Piedmont                  18
Sausalito                 20
Albany                    29
Los Altos Hills           86
El Cerrito               105
Ross                     113
San Anselmo              125
Saratoga                 164
Fairfax                  165
Corte Madera             191
Belmont                  272
Danville                 317
Atherton                 349
Los Altos                352
Campbell                 400
Orinda                   407
Union City               473
Los Gatos                493
Cloverdale               505
Larkspur                 510
Moraga                   514
Millbrae                 640
East Palo Alto           742
Lafayette                789
San Bruno                799
Dublin                   878
San Ramon                889
Foster City             1198
Menlo Park              1276
Burlingame              1379
San Mateo County        1471
San Carlos              1511
Cupertino               1622
Walnut Creek            1659
Pleasanton              1667
Alameda                 1701
Berkeley                2028
Emeryville              2033
Palo Alto               2130
San Mateo               2750
Milpitas                2759
Redwood City            2809
Concord                 3455
Santa Clara             5123
Mountain View           5748
Alameda County          5780
Contra Costa County     6415
Sunnyvale               6963
Fremont                 9828
Santa Rosa             12977
San Francisco          16723
San Jose               54625
dtype: int64
Describe of inclusionary revenue reduction:
count    3.109000e+04
mean     4.501533e+06
std      1.686400e+07
min      1.032582e+05
25%      7.705817e+05
50%      1.466225e+06
75%      3.425669e+06
max      1.569187e+09
dtype: float64
Describe of number of affordable units:
count    31091.000000
mean         5.339134
std         18.637669
min          1.000000
25%          1.000000
50%          2.000000
75%          4.000000
max       1099.000000
dtype: float64
Modifying profit for SB743:
count    408739.000000
mean          1.009342
std           0.011522
min           0.980000
25%           1.000000
50%           1.020000
75%           1.020000
max           1.020000
Name: (residential, vmt_res_cat), dtype: float64
Modifying profit for CEQA:
count    1956208.000000
mean           1.004557
std            0.004980
min            1.000000
25%            1.000000
50%            1.000000
75%            1.010000
max            1.010000
dtype: float64
Modifying profit for Reduce Parking Requirements in PDAs:
count    1956208.000000
mean           1.001351
std            0.003418
min            1.000000
25%            1.000000
50%            1.000000
75%            1.000000
max            1.010000
dtype: float64
There are 165999 affordable units if all feasible projects are built
Subaccount:  1
Number of feasible projects in receiving zone: 18286
Amount in subaccount: $653,244,996.90
Amount left after subsidy: $65,712.18
Built 1368 total subsidized buildings
    Total subsidy: $653,179,284.71
    Total subsidized units: 67603
Running the subsidized developer for acct: Parcel Tax
Describe of the yearly rent by use
              retail     industrial         office    residential
count  516070.000000  516070.000000  516070.000000  516070.000000
mean       21.240595       9.929676      24.150631      33.471029
std        13.712600       7.349648      11.322486      11.903504
min        -1.000000      -1.000000      -1.000000       7.500000
25%        17.596754       7.058057      17.485249      24.781786
50%        21.949305      10.646568      22.567047      29.979022
75%        25.263906      13.417267      30.864397      39.638265
max        73.534698      34.648678      68.692116      62.500000
Computing feasibility for form residential
Making policy modifications to profitability
Sum of residential fees:  0.0
Computing adjustments due to inclusionary housing
Revenue difference per unit (not zero values)
count     407330.000000
mean      928352.713268
std       503788.893061
min        19454.899536
25%       551825.827548
50%       789049.417226
75%      1192484.468780
max      2962899.512691
dtype: float64
Feasibile affordable units by jurisdiction
juris_name
Tiburon                   12
Belvedere                 12
Piedmont                  18
Sausalito                 20
Albany                    29
Los Altos Hills           86
El Cerrito               106
Ross                     113
San Anselmo              125
Saratoga                 164
Fairfax                  165
Corte Madera             191
Belmont                  272
Danville                 317
Atherton                 349
Los Altos                351
Campbell                 396
Orinda                   405
Union City               473
Los Gatos                493
Cloverdale               503
Larkspur                 510
Moraga                   514
Millbrae                 640
East Palo Alto           740
Lafayette                789
San Bruno                798
Dublin                   878
San Ramon                889
Foster City             1198
Menlo Park              1275
Burlingame              1358
San Mateo County        1468
San Carlos              1511
Cupertino               1618
Pleasanton              1634
Walnut Creek            1645
Alameda                 1701
Emeryville              2008
Berkeley                2025
Palo Alto               2129
San Mateo               2749
Milpitas                2759
Redwood City            2800
Concord                 3422
Santa Clara             5119
Mountain View           5737
Alameda County          5771
Contra Costa County     6353
Sunnyvale               6944
Fremont                 9828
Santa Rosa             12249
San Francisco          16692
San Jose               53571
dtype: int64
Describe of inclusionary revenue reduction:
count    3.072500e+04
mean     4.528800e+06
std      1.695568e+07
min      1.032582e+05
25%      7.807151e+05
50%      1.478400e+06
75%      3.450889e+06
max      1.569187e+09
dtype: float64
Describe of number of affordable units:
count    30726.000000
mean         5.334961
std         18.714511
min          1.000000
25%          1.000000
50%          2.000000
75%          4.000000
max       1099.000000
dtype: float64
Modifying profit for SB743:
count    407371.000000
mean          1.009318
std           0.011523
min           0.980000
25%           1.000000
50%           1.020000
75%           1.020000
max           1.020000
Name: (residential, vmt_res_cat), dtype: float64
Modifying profit for CEQA:
count    1956208.000000
mean           1.004557
std            0.004980
min            1.000000
25%            1.000000
50%            1.000000
75%            1.010000
max            1.010000
dtype: float64
Modifying profit for Reduce Parking Requirements in PDAs:
count    1956208.000000
mean           1.001351
std            0.003418
min            1.000000
25%            1.000000
50%            1.000000
75%            1.000000
max            1.010000
dtype: float64
There are 163922 affordable units if all feasible projects are built
Subaccount:  1
Number of feasible projects in receiving zone: 16888
Amount in subaccount: $9,203,832,889.64
Amount left after subsidy: $1,893,450,724.20
Built 5404 total subsidized buildings
    Total subsidy: $7,310,382,165.44
    Total subsidized units: 136102
Running the subsidized developer for acct: Capital Gains Tax
Describe of the yearly rent by use
              retail     industrial         office    residential
count  512034.000000  512034.000000  512034.000000  512034.000000
mean       21.197830       9.911679      24.153671      33.496040
std        13.727043       7.365983      11.341801      11.908699
min        -1.000000      -1.000000      -1.000000       7.500000
25%        17.552664       7.042593      17.464588      24.789423
50%        21.935413      10.646568      22.575712      30.007880
75%        25.224487      13.417267      30.883244      39.676459
max        73.534698      34.648678      68.692116      62.500000
Computing feasibility for form residential
Making policy modifications to profitability
Sum of residential fees:  0.0
Computing adjustments due to inclusionary housing
Revenue difference per unit (not zero values)
count     403307.000000
mean      932890.803678
std       503170.074645
min        19454.899536
25%       555425.847340
50%       795337.922774
75%      1196956.790835
max      2962899.512691
dtype: float64
Feasibile affordable units by jurisdiction
juris_name
Tiburon                   12
Belvedere                 12
Piedmont                  18
Sausalito                 20
Albany                    29
Los Altos Hills           86
El Cerrito                86
Ross                     113
San Anselmo              125
Saratoga                 164
Fairfax                  165
Corte Madera             191
Belmont                  272
Danville                 314
Atherton                 349
Los Altos                351
Campbell                 382
Orinda                   407
Union City               473
Cloverdale               492
Los Gatos                493
Larkspur                 510
Moraga                   514
Millbrae                 633
East Palo Alto           741
Lafayette                789
San Bruno                799
San Ramon                875
Dublin                   878
Foster City             1198
Menlo Park              1275
Burlingame              1330
San Mateo County        1471
San Carlos              1511
Cupertino               1603
Walnut Creek            1655
Pleasanton              1667
Alameda                 1701
Emeryville              2013
Berkeley                2026
Palo Alto               2127
Milpitas                2735
San Mateo               2744
Redwood City            2801
Concord                 3427
Santa Clara             5079
Alameda County          5700
Mountain View           5746
Contra Costa County     6355
Sunnyvale               6900
Fremont                 9820
Santa Rosa             12151
San Francisco          16576
San Jose               52965
dtype: int64
Describe of inclusionary revenue reduction:
count    3.011400e+04
mean     4.607216e+06
std      1.712503e+07
min      1.032582e+05
25%      8.032445e+05
50%      1.521672e+06
75%      3.556283e+06
max      1.569585e+09
dtype: float64
Describe of number of affordable units:
count    30115.000000
mean         5.408235
std         18.891494
min          1.000000
25%          1.000000
50%          2.000000
75%          4.000000
max       1099.000000
dtype: float64
Modifying profit for SB743:
count    403348.000000
mean          1.009246
std           0.011530
min           0.980000
25%           1.000000
50%           1.020000
75%           1.020000
max           1.020000
Name: (residential, vmt_res_cat), dtype: float64
Modifying profit for CEQA:
count    1956208.000000
mean           1.004557
std            0.004980
min            1.000000
25%            1.000000
50%            1.000000
75%            1.010000
max            1.010000
dtype: float64
Modifying profit for Reduce Parking Requirements in PDAs:
count    1956208.000000
mean           1.001351
std            0.003418
min            1.000000
25%            1.000000
50%            1.000000
75%            1.000000
max            1.010000
dtype: float64
There are 162869 affordable units if all feasible projects are built
Subaccount:  1
Number of feasible projects in receiving zone: 12757
Amount in subaccount: $676,246,475.21
Amount left after subsidy: $61,429.42
Built 1310 total subsidized buildings
    Total subsidy: $676,185,045.79
    Total subsidized units: 68761
Time to execute step 'subsidized_residential_developer_lump_sum_accts': 311.99 s
Running step 'subsidized_residential_feasibility'
Describe of the yearly rent by use
              retail     industrial         office    residential
count  516128.000000  516128.000000  516128.000000  516128.000000
mean       21.241411       9.929931      24.150677      33.470933
std        13.711987       7.349228      11.322055      11.902910
min        -1.000000      -1.000000      -1.000000       7.500000
25%        17.596754       7.058057      17.485249      24.782036
50%        21.949305      10.646568      22.565186      29.979039
75%        25.263906      13.409309      30.864397      39.637934
max        73.534698      34.648678      68.692116      62.500000
Computing feasibility for form residential
Traceback (most recent call last):
  File "run.py", line 212, in <module>
    run_models(MODE, SCENARIO)
  File "run.py", line 129, in run_models
    orca.run(models, iter_vars=years_to_run)
  File "/bayarea_urbansim/src/orca/orca/orca.py", line 1876, in run
    step()
  File "/bayarea_urbansim/src/orca/orca/orca.py", line 780, in __call__
    return self._func(**kwargs)
  File "/bayarea_urbansim/baus/subsidies.py", line 570, in subsidized_residential_feasibility
    **kwargs)
  File "/bayarea_urbansim/src/urbansim-defaults/urbansim_defaults/utils.py", line 653, in run_feasibility
    pass_through=pass_through)
  File "/bayarea_urbansim/src/urbansim/urbansim/developer/sqftproforma.py", line 523, in lookup
    pass_through)
  File "/bayarea_urbansim/src/urbansim/urbansim/developer/sqftproforma.py", line 559, in _lookup_parking_cfg
    df = df.copy()
  File "/home/vagrant/anaconda/lib/python2.7/site-packages/pandas/core/generic.py", line 2427, in copy
    data = self._data.copy(deep=deep)
  File "/home/vagrant/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 2699, in copy
    do_integrity_check=False)
  File "/home/vagrant/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 2470, in apply
    bm._consolidate_inplace()
  File "/home/vagrant/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 2839, in _consolidate_inplace
    self.blocks = tuple(_consolidate(self.blocks))
  File "/home/vagrant/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 3821, in _consolidate
    _can_consolidate=_can_consolidate)
  File "/home/vagrant/anaconda/lib/python2.7/site-packages/pandas/core/internals.py", line 3847, in _merge_blocks
    new_values = new_values[argsort]
MemoryError
None
Closing remaining open files:./data/2015_09_01_bayarea_v3.h5...done./data/2015_06_01_osm_bayarea4326.h5...done./data/2015_08_03_tmnet.h5...done