### PR TITLE
functionality to subsidized commercial developments

### DIFF
--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -34,7 +34,8 @@ def profit_to_prob_func(df):
 @orca.injectable("coffer", cache=True)
 def coffer(settings):
     d = {
-        "vmt_fee_acct":  accounts.Account("vmt_fee_acct")
+        "vmt_res_acct":  accounts.Account("vmt_res_acct"),
+        "vmt_com_acct":  accounts.Account("vmt_com_acct")
     }
 
     for key, acct in settings["acct_settings"]["lump_sum_accounts"].items():
@@ -321,20 +322,22 @@ def calculate_vmt_fees(settings, year, buildings, vmt_fee_categories, coffer,
 
     total_fees = 0
 
-    if settings.get("vmt_fee_res", False):
+    if settings.get("vmt_res_for_res", False):
 
-        df["res_fees"] = df.vmt_res_cat.map(vmt_settings["res_fee_amounts"])
-        total_fees += (df.res_fees * df.residential_units).sum()
+        df["res_for_res_fees"] = df.vmt_res_cat.map(
+            vmt_settings["res_for_res_fee_amounts"])
+        total_fees += (df.res_for_res_fees * df.residential_units).sum()
         print "Applying vmt fees to %d units" % df.residential_units.sum()
 
-    if settings.get("vmt_fee_com", False):
+    if settings.get("vmt_com_for_res", False):
 
-        df["com_fees"] = df.vmt_res_cat.map(vmt_settings["com_fee_amounts"])
-        total_fees += (df.com_fees * df.non_residential_sqft).sum()
+        df["com_for_res_fees"] = df.vmt_res_cat.map(
+            vmt_settings["com_for_res_fee_amounts"])
+        total_fees += (df.com_for_res_fees * df.non_residential_sqft).sum()
         print "Applying vmt fees to %d commerical sqft" % \
             df.non_residential_sqft.sum()
 
-    print "Adding total vmt fees amount of $%.2f" % total_fees
+    print "Adding total vmt fees for res amount of $%.2f" % total_fees
 
     metadata = {
         "description": "VMT development fees",
@@ -342,8 +345,103 @@ def calculate_vmt_fees(settings, year, buildings, vmt_fee_categories, coffer,
     }
     # the subaccount is meaningless here (it's a regional account) -
     # but the subaccount number is referred to below
-    coffer["vmt_fee_acct"].add_transaction(total_fees, subaccount=1,
+    coffer["vmt_res_acct"].add_transaction(total_fees, subaccount=1,
                                            metadata=metadata)
+
+    total_fees = 0
+
+    if settings.get("vmt_com_for_com", False):
+
+        df["com_for_com_fees"] = df.vmt_res_cat.map(
+            vmt_settings["com_for_com_fee_amounts"])
+        total_fees += (df.com_for_com_fees * df.non_residential_sqft).sum()
+        print "Applying vmt fees to %d commerical sqft" % \
+            df.non_residential_sqft.sum()
+
+    print "Adding total vmt fees for com amount of $%.2f" % total_fees
+
+    coffer["vmt_com_acct"].add_transaction(total_fees, subaccount=1,
+                                           metadata=metadata)
+
+
+@orca.step()
+def subsidized_office_developer(feasibility, coffer, acct_settings, year):
+
+    # get the total subsidy for subsidizing office
+    total_subsidy = coffer["vmt_com_acct"].\
+        total_transactions_by_subacct("regional")
+
+    # get the office feasibility frame and sort by profit per sqft
+    feasibility = feasibility.to_frame().loc[:, "office"]
+    feasibility = feasibility.dropna(subset=["max_profit"])
+
+    # filter to receiving zone
+    feasibility = feasibility.\
+        query(acct_settings["vmt_settings"]["receiving_buildings_filter"])
+
+    feasibility["non_residential_sqft"] = \
+        feasibility.non_residential_sqft.astype("int")
+
+    feasibility["max_profit_per_sqft"] = df.max_profit / \
+        df.non_residential_sqft
+
+    # sorting by our choice metric as we're going to pick our devs
+    # in order off the top
+    feasibility = feasibility.sort(columns=['max_profit_per_sqft'],
+                                   ascending=True)
+
+    devs = []
+
+    for dev_id, d in feasibility.iterrows():
+
+        # the logic here is that we allow each dev to have a "normal"
+        # profit per square foot and once it does we guarantee that it
+        # gets build - we assume the planning commission for each city
+        # enables this to happen.  If a project gets enough profit already
+        # we just allow it to compete on the open market - e.g. in the
+        # non-subsidized office developer
+
+        NORMAL_PROFIT_PER_SQFT = 50  # assume price is around $500/sqft
+
+        if d.max_profit_per_sqft >= NORMAL_PROFIT_PER_SQFT:
+            #  competes in open market
+            continue
+        else:
+            amt = NORMAL_PROFIT_PER_SQFT * d.max_profit_per_sqft * \
+                d.non_residential_sqft
+
+            if amt > total_subsidy:
+                # we don't have enough money to buy yet
+                continue
+
+        metadata = {
+            "description": "Developing subsidized office building",
+            "year": year,
+            "non_residential_sqft": d["non_residential_sqft"]
+            "index": dev_id
+        }
+        account.add_transaction(amt, subaccount=subacct, metadata=metadata)
+
+        total_subsidy -= amt
+
+        devs.append(d)
+
+    if len(devs) == 0:
+        return
+
+    # record keeping - add extra columns to match building dataframe
+    # add the buidings and demolish old buildings, and add to debug output
+    devs = pd.DataFrame(devs, columns=feasibility.columns)
+
+    print "Building {:,} subsidized office sqft in {:,} projects".format(
+        devs.non_residential_sqft.sum(), len(devs))
+
+    devs["form"] = "office"
+    devs = add_extra_columns_func(devs)
+
+    add_buildings(buildings, devs)
+
+    summary.add_parcel_output(devs)
 
 
 def run_subsidized_developer(feasibility, parcels, buildings, households,
@@ -629,7 +727,7 @@ def subsidized_residential_developer_vmt(
                              households,
                              acct_settings["vmt_settings"],
                              settings,
-                             coffer["vmt_fee_acct"],
+                             coffer["vmt_res_acct"],
                              year,
                              form_to_btype_func,
                              add_extra_columns_func,

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -361,7 +361,7 @@ def calculate_vmt_fees(settings, year, buildings, vmt_fee_categories, coffer,
 
     print "Adding total vmt fees for com amount of $%.2f" % total_fees
 
-    coffer["vmt_com_acct"].add_transaction(total_fees, subaccount=1,
+    coffer["vmt_com_acct"].add_transaction(total_fees, subaccount="regional",
                                            metadata=metadata)
 
 
@@ -396,7 +396,7 @@ def subsidized_office_developer(feasibility, coffer, acct_settings, year,
     # make parcel_id available
     feasibility = feasibility.reset_index()
 
-    print "%.3f subsidy with %d developments to choose from" % (
+    print "%.0f subsidy with %d developments to choose from" % (
         total_subsidy, len(feasibility))
 
     devs = []
@@ -410,7 +410,7 @@ def subsidized_office_developer(feasibility, coffer, acct_settings, year,
         # we just allow it to compete on the open market - e.g. in the
         # non-subsidized office developer
 
-        NORMAL_PROFIT_PER_SQFT = 50  # assume price is around $500/sqft
+        NORMAL_PROFIT_PER_SQFT = 70  # assume price is around $700/sqft
 
         if d.max_profit_per_sqft >= NORMAL_PROFIT_PER_SQFT:
             #  competes in open market
@@ -429,15 +429,13 @@ def subsidized_office_developer(feasibility, coffer, acct_settings, year,
             "non_residential_sqft": d["non_residential_sqft"],
             "index": dev_id
         }
-        coffer["vmt_res_acct"].add_transaction(amt, subaccount="reagional",
+
+        coffer["vmt_com_acct"].add_transaction(-1*amt, subaccount="regional",
                                                metadata=metadata)
 
         total_subsidy -= amt
 
         devs.append(d)
-
-    print "Subsidizing %d developments with %.3f remaining subsidy" % (
-        len(devs), total_subsidy)
 
     if len(devs) == 0:
         return

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -367,13 +367,14 @@ def vmt_res_cat(parcels, vmt_fee_categories):
 @orca.column('parcels', cache=True)
 def vmt_res_fees(parcels, settings):
     vmt_settings = settings["acct_settings"]["vmt_settings"]
-    return parcels.vmt_res_cat.map(vmt_settings["res_fee_amounts"])
+    return parcels.vmt_res_cat.map(vmt_settings["res_for_res_fee_amounts"])
 
 
 @orca.column('parcels', cache=True)
 def vmt_com_fees(parcels, settings):
     vmt_settings = settings["acct_settings"]["vmt_settings"]
-    return parcels.vmt_res_cat.map(vmt_settings["com_fee_amounts"])
+    return parcels.vmt_res_cat.map(vmt_settings["com_for_res_fee_amounts"]) + \
+        parcels.vmt_res_cat.map(vmt_settings["com_for_com_fee_amounts"])
 
 
 # compute the fees per unit for each parcel

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -434,11 +434,15 @@ acct_settings:
   vmt_settings:
     sending_buildings_subaccount_def: regional
     receiving_buildings_filter: pda_id>0
-    res_fee_amounts:
+    res_for_res_fee_amounts:
       VH: 25000
       H: 15000
       MH: 5000
-    com_fee_amounts:
+    com_for_res_fee_amounts:
+      VH: 45
+      H: 22
+      MH: 12
+    com_for_com_fee_amounts:  # commercial fee subsidizing commercial devs
       VH: 45
       H: 22
       MH: 12

--- a/run.py
+++ b/run.py
@@ -271,8 +271,8 @@ if MODE == "simulation":
     prev_run = LAST_KNOWN_GOOD_RUNS[SCENARIO]
     # fetch the previous run off of the internet for comparison - the "last
     # known good run" should always be available on EC2
-    df1 = pd.read_csv("http://urbanforecast.com/runs/run%d_superdistrict" +
-                      "_summaries_2040.csv" % prev_run)
+    df1 = pd.read_csv(("http://urbanforecast.com/runs/run%d_superdistrict" +
+                       "_summaries_2040.csv") % prev_run)
     df1 = df1.set_index(df1.columns[0]).sort_index()
 
     df2 = pd.read_csv("runs/run%d_superdistrict_summaries_2040.csv" % run_num)

--- a/run.py
+++ b/run.py
@@ -109,12 +109,20 @@ def get_simulation_models(SCENARIO):
 
         # note that you might also have to change the fees that get
         # imposed - look for fees_per_unit column in variables.py
+
         if SCENARIO == "3":
-            orca.get_injectable("settings")["vmt_fee_res"] = True
+            orca.get_injectable("settings")["vmt_res_for_res"] = True
+
         if SCENARIO == "1":
-            orca.get_injectable("settings")["vmt_fee_com"] = True
+            orca.get_injectable("settings")["vmt_com_for_res"] = True
+
         if SCENARIO == "4":
-            orca.get_injectable("settings")["vmt_fee_com"] = True
+            orca.get_injectable("settings")["vmt_com_for_res"] = True
+            orca.get_injectable("settings")["vmt_com_for_com"] = True
+
+            models.insert(models.index("office_developer"),
+                          "subsidized_office_developer")
+
         models.insert(models.index("diagnostic_output"),
                       "calculate_vmt_fees")
         models.insert(models.index("alt_feasibility"),
@@ -263,7 +271,8 @@ if MODE == "simulation":
     prev_run = LAST_KNOWN_GOOD_RUNS[SCENARIO]
     # fetch the previous run off of the internet for comparison - the "last
     # known good run" should always be available on EC2
-    df1 = pd.read_csv("http://urbanforecast.com/runs/run%d_superdistrict_summaries_2040.csv" % prev_run)
+    df1 = pd.read_csv("http://urbanforecast.com/runs/run%d_superdistrict" +
+                      "_summaries_2040.csv" % prev_run)
     df1 = df1.set_index(df1.columns[0]).sort_index()
 
     df2 = pd.read_csv("runs/run%d_superdistrict_summaries_2040.csv" % run_num)


### PR DESCRIPTION
@mkreilly this appears to be working...  just edit the com_for_com_fee_amounts section in settings.yaml.  Note some of the keys have been changes to be explicit about what it subsidizing what.

this functionality charges fees to new commercial development in high vmt areas that are used to subsidize commercial development in low vmt areas.  Similar functionality already existed to subsidize residential, but this is the first time we've worked towards subsidizing office (not retail yet)
